### PR TITLE
impossibilité de créer en doublon et msg erreur si API ne renvoie rien

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma'
 gem 'rails', '5.2.1'
 gem 'redis'
 gem 'dotenv-rails', groups: [:development, :test]
+gem 'pg_search'
 
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,10 @@ GEM
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     pg (0.21.0)
+    pg_search (2.1.2)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      arel (>= 6)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -213,6 +217,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   listen (~> 3.0.5)
   pg (~> 0.21)
+  pg_search
   pry-byebug
   pry-rails
   puma

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -20,7 +20,7 @@ class ComicsController < ApplicationController
       flash[:alert] = "Veuillez renouveller votre recherche, nous n'avons trouvé aucune correspondance"
       render :new
     elsif @comic.save
-      redirect_to new_album_path(comic_id: @comic.id.to_s), notice: "#{@comic.title} est disponible"
+      redirect_to new_album_path(comic_id: @comic.id.to_s), notice: "#{@comic.title} est maintenant disponible"
     else
       render :new
     end
@@ -33,8 +33,8 @@ class ComicsController < ApplicationController
   end
 
   def check_doubles(title_query, isbn_query)
-    # Check if the result of the search raises matches in our DB
-    sql_query = " title ILIKE :title_query OR isbn = :isbn_query "
+    # Check if the result of the search for 'API add' raises matches in our DB
+    sql_query = " title @@ :title_query OR isbn = :isbn_query "
     @comics = Comic.where(sql_query, title_query: title_query.to_s, isbn_query: isbn_query.to_s)
     return @comics.first unless @comics.empty?
   end

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -11,9 +11,16 @@ class ComicsController < ApplicationController
     title_query = comic_params[:title]
     isbn_query = comic_params[:isbn]
 
-    @comic = Comic.new(request_informations(title_query, isbn_query))
-    if @comic.save
-      redirect_to new_album_path(comic_id: @comic.id.to_s), notice: "#{@comic.title} a bien été créé."
+    @comic = Comic.new(store_informations(title_query, isbn_query))
+
+    @comic_found = check_doubles(title_query, isbn_query)
+    if !@comic_found.nil?
+      redirect_to new_album_path(comic_id: @comic_found.id.to_s), notice: "Un correspondance a été trouvée dans la liste"
+    elsif store_informations(title_query, isbn_query).nil?
+      flash[:alert] = "Veuillez renouveller votre recherche, nous n'avons trouvé aucune correspondance"
+      render :new
+    elsif @comic.save
+      redirect_to new_album_path(comic_id: @comic.id.to_s), notice: "#{@comic.title} est disponible"
     else
       render :new
     end
@@ -25,22 +32,29 @@ class ComicsController < ApplicationController
     params.require(:comic).permit(:title, :author, :artwork, :category, :isbn)
   end
 
-  def api_url(title_query, isbn_query)
-    url_raw = 'https://www.googleapis.com/books/v1/volumes?q='
-    query_title = title_query
-    query_isbn = isbn_query
-
-    "#{url_raw}#{query_title}+isbn:#{query_isbn}&key=#{ENV['GOOGLE_API_KEY']}"
+  def check_doubles(title_query, isbn_query)
+    # Check if the result of the search raises matches in our DB
+    sql_query = " title ILIKE :title_query OR isbn = :isbn_query "
+    @comics = Comic.where(sql_query, title_query: title_query.to_s, isbn_query: isbn_query.to_s)
+    return @comics.first unless @comics.empty?
   end
 
-  def request_informations(title_query, isbn_query)
-    url = api_url(title_query, isbn_query)
+  def request_informations_from_api(title_query, isbn_query)
+    url_api = 'https://www.googleapis.com/books/v1/volumes?q='
+    url = "#{url_api}#{title_query}+isbn:#{isbn_query}&key=#{ENV['GOOGLE_API_KEY']}"
     response = open(url).read
-    informations_raw = JSON.parse(response)
+    return JSON.parse(response)
+  end
 
+  def store_informations(title_query, isbn_query)
+    # Check if the search returns informations
+    informations_raw = request_informations_from_api(title_query, isbn_query)
+    return nil if informations_raw['totalItems'].zero?
+
+    # Store informations from API call
     title = informations_raw['items'][0]['volumeInfo']['title']
     author = informations_raw['items'][0]['volumeInfo']['authors'][0] unless informations_raw['items'][0]['volumeInfo']['authors'].nil?
-    isbn = informations_raw['items'][0]['volumeInfo']['industryIdentifiers'][0]['identifier']
+    isbn = informations_raw['items'][0]['volumeInfo']['industryIdentifiers'][0]['identifier'] unless informations_raw['items'][0]['volumeInfo']['industryIdentifiers'].nil?
     artwork = informations_raw['items'][0]['volumeInfo']['imageLinks']['smallThumbnail'] unless informations_raw['items'][0]['volumeInfo']['imageLinks'].nil?
     return { title: title, author: author, artwork: artwork, isbn: isbn }
   end

--- a/app/controllers/comics_controller.rb
+++ b/app/controllers/comics_controller.rb
@@ -33,9 +33,12 @@ class ComicsController < ApplicationController
   end
 
   def check_doubles(title_query, isbn_query)
-    # Check if the result of the search for 'API add' raises matches in our DB
-    sql_query = " title @@ :title_query OR isbn = :isbn_query "
-    @comics = Comic.where(sql_query, title_query: title_query.to_s, isbn_query: isbn_query.to_s)
+    # Check if the result of the search for 'API add' raises matches in our DB (first with ISBN, then with a PG search on title)
+    sql_query = " isbn = :isbn_query "
+    @comics = Comic.where(sql_query, isbn_query: isbn_query)
+
+    Comic.search_by_title(title_query).each { |comic| @comics << comic } unless Comic.search_by_title(title_query).empty?
+
     return @comics.first unless @comics.empty?
   end
 

--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -1,3 +1,10 @@
 class Comic < ApplicationRecord
   has_many :albums
+
+  include PgSearch
+  pg_search_scope :search_by_title,
+    against: [:title],
+    using: {
+      tsearch: { prefix: true }
+    }
 end

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -4,21 +4,16 @@
   <div class="form-inputs">
     <%= f.input :description,
                 required: true,
-                autofocus: true %>
-    <% if @comic %>
-      <%= f.association :comic, selected: @comic %>
-    <% else %>
-      <%= f.association :comic, :collection => Comic.all.order(:title) %>
-    <% end %>
+                autofocus: true,
+                label: 'Description' %>
+    <%= f.association :comic, :collection => Comic.all.order(:title), label: 'Référence BD' %>
 
-    <% if @comic.nil? %>
-      <%= render 'add-comic' %>
-    <% end %>
+    <%= render 'add-comic' %>
 
     <%= f.input :available, label: 'Disponible pour un prêt?', as: :boolean, :input_html => { :checked => true }, checked_value: 'true', unchecked_value: 'false' %>
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit %>
+    <%= f.button :submit, "Créer l'album" %>
   </div>
 <% end %>

--- a/app/views/comics/_form.html.erb
+++ b/app/views/comics/_form.html.erb
@@ -7,6 +7,6 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit %>
+    <%= f.button :submit, 'Nouvelle référence' %>
   </div>
 <% end %>

--- a/app/views/comics/new.html.erb
+++ b/app/views/comics/new.html.erb
@@ -2,3 +2,6 @@
   <h2>Ajouter une nouvelle référence de BD</h2>
   <%= render 'form', comic: @comic %>
 </div>
+<div class='container form-container'>
+  <%= link_to "Revenir", new_album_path %>
+</div>


### PR DESCRIPTION
Grosse update sur la création d'instances Comic : 
- suppression de la possibilité de générer des doublons (search sur le nom et/ou sur l'ISBN)
- renvoie un message d'erreur si l'API ne renvoie aucun résultat
- pas mal de petits changements associés (obligation d'un title sur l'instance Comic, etc ..)